### PR TITLE
release 1.0.4

### DIFF
--- a/src/application/utils/petitionStatus.ts
+++ b/src/application/utils/petitionStatus.ts
@@ -1,14 +1,24 @@
-const checkPetitionStatus = (petition?: Petition): PetitionStatus => {
+const deprecatedCheckPetitionStatus = (petition?: Petition): PetitionStatus => {
+  const REQUIRED_AGREEMENT_COUNTS = 50;
   if (!petition) return '청원 진행중';
   /**
    * @description 답변을 요청하기 위한 최소 동의 수
    */
-  const REQUIRED_AGREEMENT_COUNTS = 50;
-  if (!petition.released) return '승인 대기중';
-  if (petition.rejected) return '승인 반려됨';
+  // if (!petition.released) return '승인 대기중';
+  // if (petition.rejected) return '승인 반려됨';
   if (petition.answered) return '답변 완료됨';
   if (petition.expired) return '청원 만료됨';
   return petition.agreeCount >= REQUIRED_AGREEMENT_COUNTS ? '답변 대기중' : '청원 진행중';
+};
+
+const checkPetitionStatus = (petition?: Petition): PetitionStatus => {
+  const REQUIRED_AGREEMENT_COUNTS = 50;
+  if (!petition) return '청원 진행중';
+  if (petition.status === 'RELEASED')
+    return petition.agreeCount >= REQUIRED_AGREEMENT_COUNTS ? '답변 대기중' : '청원 진행중';
+  if (petition.status === 'ANSWERED') return '답변 완료됨';
+  if (petition.status === 'REJECTED') return '승인 반려됨';
+  return '청원 진행중';
 };
 
 export default checkPetitionStatus;

--- a/src/application/utils/petitionStatus.ts
+++ b/src/application/utils/petitionStatus.ts
@@ -14,6 +14,7 @@ const deprecatedCheckPetitionStatus = (petition?: Petition): PetitionStatus => {
 const checkPetitionStatus = (petition?: Petition): PetitionStatus => {
   const REQUIRED_AGREEMENT_COUNTS = 50;
   if (!petition) return '청원 진행중';
+  if (petition.status === 'TEMPORARY') return '사전 동의중';
   if (petition.status === 'RELEASED')
     return petition.agreeCount >= REQUIRED_AGREEMENT_COUNTS ? '답변 대기중' : '청원 진행중';
   if (petition.status === 'ANSWERED') return '답변 완료됨';

--- a/src/infrastructure/types/Petition.d.ts
+++ b/src/infrastructure/types/Petition.d.ts
@@ -23,7 +23,15 @@ interface Rejection {
   updatedAt: number;
 }
 
-type PetitionStatus = '승인 대기중' | '청원 진행중' | '답변 대기중' | '답변 완료됨' | '승인 반려됨' | '청원 만료됨';
+type PetitionStatus =
+  | '승인 대기중'
+  | '청원 진행중'
+  | '답변 대기중'
+  | '답변 완료됨'
+  | '승인 반려됨'
+  | '청원 만료됨'
+  | '사전 동의중';
+
 interface Answer {
   description: string;
   createdAt: number;

--- a/src/infrastructure/types/Petition.d.ts
+++ b/src/infrastructure/types/Petition.d.ts
@@ -10,11 +10,10 @@ interface Petition {
   updatedAt: number;
   userId: number;
   tempUrl: string;
-  released: boolean;
-  rejected: boolean;
   rejection?: Rejection;
   expired: boolean;
   waitingForAnswerAt: number;
+  status: 'TEMPORARY' | 'RELEASED' | 'REJECTED' | 'ANSWERED';
 }
 
 interface Rejection {

--- a/src/presentation/components/PetitionList/VPetitionItem.tsx
+++ b/src/presentation/components/PetitionList/VPetitionItem.tsx
@@ -99,6 +99,7 @@ const statusColor = {
   '답변 완료됨': '#ad2e24',
   '승인 반려됨': '#DF3127',
   '청원 만료됨': '#7a1c0b',
+  '사전 동의중': '#a8714c',
 };
 
 interface vPetitionItemProps {

--- a/src/presentation/components/common/VPetition.tsx
+++ b/src/presentation/components/common/VPetition.tsx
@@ -63,6 +63,7 @@ const statusColor = {
   '답변 완료됨': '#ad2e24',
   '승인 반려됨': '#DF3127',
   '청원 만료됨': '#7a1c0b',
+  '사전 동의중': '#a8714c',
 };
 
 const MLine = styled(StLine)`

--- a/src/presentation/pages/ApprovePetition.tsx
+++ b/src/presentation/pages/ApprovePetition.tsx
@@ -48,11 +48,15 @@ const ApprovePetition = (): JSX.Element => {
       return;
     }
 
-    const response = petition?.rejected
-      ? await putPetitionRejection(petition?.id, rejectDescription)
-      : await postPetitionRejection(petition?.id, rejectDescription);
+    const response =
+      petition?.status === 'REJECTED'
+        ? await putPetitionRejection(petition?.id, rejectDescription)
+        : await postPetitionRejection(petition?.id, rejectDescription);
     if (response.status === 201 || response.status === 200) {
-      toast({ message: `${petition?.rejected ? '반려 사유가 수정' : '청원이 반려'}되었습니다.`, type: 'warning' });
+      toast({
+        message: `${petition?.status === 'REJECTED' ? '반려 사유가 수정' : '청원이 반려'}되었습니다.`,
+        type: 'warning',
+      });
       navigate('/');
     } else {
       toast({ message: response.data?.message, type: 'warning' });
@@ -95,8 +99,10 @@ const ApprovePetition = (): JSX.Element => {
                   <Title>청원 반려</Title>
                   <ButtonWrapper>
                     <StButton onClick={handleCancel}>취소</StButton>
-                    {petition?.rejected ? <StButton onClick={cancelReject}>반려 취소</StButton> : null}
-                    <StButton onClick={handleReject}>{petition?.rejected ? '반려 수정' : '청원 반려'}</StButton>
+                    {petition?.status === 'REJECTED' ? <StButton onClick={cancelReject}>반려 취소</StButton> : null}
+                    <StButton onClick={handleReject}>
+                      {petition?.status === 'REJECTED' ? '반려 수정' : '청원 반려'}
+                    </StButton>
                   </ButtonWrapper>
                 </TitleWrapper>
                 <Writer value={rejectDescription} onChange={handleChange} />
@@ -104,8 +110,10 @@ const ApprovePetition = (): JSX.Element => {
             ) : (
               <ButtonWrapper>
                 <StButton onClick={handleModify}>청원 수정</StButton>
-                <StButton onClick={handleReject}>{petition?.rejected ? '반려 수정' : '청원 반려'}</StButton>
-                {petition?.rejected ? null : <StButton onClick={handleApprove}>청원 승인</StButton>}
+                <StButton onClick={handleReject}>
+                  {petition?.status === 'REJECTED' ? '반려 수정' : '청원 반려'}
+                </StButton>
+                {petition?.status === 'REJECTED' ? null : <StButton onClick={handleApprove}>청원 승인</StButton>}
               </ButtonWrapper>
             )}
           </>

--- a/src/presentation/pages/ManagePetition.tsx
+++ b/src/presentation/pages/ManagePetition.tsx
@@ -67,7 +67,7 @@ const ManagePetition = (): JSX.Element => {
       ) : null}
       <ButtonWrapper>
         <StButton onClick={navigateModify}>청원 수정</StButton>
-        {petition?.rejected ? (
+        {petition?.status === 'REJECTED' ? (
           <StButton onClick={navigateApprove}>반려 수정</StButton>
         ) : (
           <StButton onClick={withdrawPetition}>승인 취소</StButton>


### PR DESCRIPTION
@wannte 
기존에 작업을 불편하게 했던 Boolean의 조합들을 개선해서 status가 해당 상태를 가지도록 수정했습니다.
예시: status: "RELEASED"
Status는 아래 4종류이며,
```
TEMPORARY,
RELEASED,
REJECTED,
ANSWERED
```
여전히 승인/답변 대기중은 동의 수를 비교, 만료 여부는 또 별도의 칼럼으로 관리하고 있습니다.
해당 부분 반영하시고 나면 released, answered, rejected 칼럼을 삭제할 예정입니다.

의 요구사항에 맞게 청원 진행 상태를 확인할때 해당 칼럼을 더이상 이용하지 않도록 수정하였습니다. 